### PR TITLE
Bump up version to v0.4.7

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TCIAlgorithms"
 uuid = "baf62351-2e82-41dd-9129-4f5768a618e1"
 authors = ["Hiroshi Shinaoka <h.shinaoka@gmail.com> and contributors"]
-version = "0.4.6"
+version = "0.4.7"
 
 [deps]
 Coverage = "a2441757-f6aa-5fb2-8edb-039e3f45d037"


### PR DESCRIPTION
This PR updates patch version of TCIAlgorithms.jl. 

[TCIAlgorithms.jl](https://github.com/tensor4all/TCIAlgorithms.jl) v0.4 is the last version that supports Quantics v0.3.

